### PR TITLE
Allow more than 100 users in group

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,3 +1,5 @@
+// This code is taken from https://github.com/Fullscreen/iam-authorized-keys-command
+// Its responsibility is to query iam service for users that match criteria, and list them with ssh public keys
 package main
 
 import (
@@ -69,7 +71,10 @@ func main() {
 						SSHPublicKeyId: k.SSHPublicKeyId,
 						UserName:       userName,
 					}
-					resp, _ := svc.GetSSHPublicKey(params)
+					resp, err := svc.GetSSHPublicKey(params)
+					if err != nil {
+						fmt.Fprintln(os.Stderr, err.Error())
+					}
 					fmt.Printf("# %s\n", *userName)
 					fmt.Println(*resp.SSHPublicKey.SSHPublicKeyBody)
 				}
@@ -85,12 +90,13 @@ func users(svc *iam.IAM, iamGroup string) ([]*iam.User, error) {
 	if iamGroup != "" {
 		params := &iam.GetGroupInput{
 			GroupName: aws.String(iamGroup),
+			MaxItems:  aws.Int64(1000),
 		}
 		resp, err := svc.GetGroup(params)
 		return resp.Users, err
 	}
 	params := &iam.ListUsersInput{
-		MaxItems: aws.Int64(100),
+		MaxItems: aws.Int64(1000),
 	}
 	resp, err := svc.ListUsers(params)
 	return resp.Users, err

--- a/main.go
+++ b/main.go
@@ -78,6 +78,8 @@ func main() {
 					fmt.Printf("# %s\n", *userName)
 					fmt.Println(*resp.SSHPublicKey.SSHPublicKeyBody)
 				}
+			} else {
+				fmt.Fprintln(os.Stderr, err.Error())
 			}
 			wg.Done()
 		}(u.UserName)


### PR DESCRIPTION
These changes add error handling and permit up to 1000 (max service limit for unpaged responses) users to be returned when an IAM group is specified. Previously if there were more than 100 users in group then users past that number would not be returned